### PR TITLE
Fix/docs generate

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ This macro returns an alternative warehouse if conditions are met. It will, in o
 
 - The relation doesn't exist (initial run) _and_ a warehouse has been configured
 - Full refresh run _and_ a warehouse has been configured
-- Incremental run _and_ a warehouse has been configured
 
 Otherwise, it returns the target warehouse configured in the profile.
 
@@ -40,7 +39,6 @@ Out-of-the-box, the macro will return the `target.warehouse` for each condition,
 |----------|-------------|:--------:|
 |snowflake_utils:initial_run_warehouse|Alternative warehouse when the relation doesn't exist|No|
 |snowflake_utils:full_refresh_run_warehouse|Alternative warehouse when doing a `--full-refresh`|No|
-|snowflake_utils:incremental_run_warehouse|Alternative warehouse to use for incremental runs|No|
 
 An example `dbt_project.yml` configuration:
 

--- a/macros/warehouse_size.sql
+++ b/macros/warehouse_size.sql
@@ -8,34 +8,34 @@
         {% set full_wh = var('snowflake_utils:full_refresh_run_warehouse', none) %}
         {% set inc_wh = var('snowflake_utils:incremental_run_warehouse', none) %}
 
-        {#- use alternative warehouse if initial run #}
+        {#-- use alternative warehouse if initial run #}
         {% if relation is none and initial_wh is not none %}
             {{ dbt_utils.log_info("Initial Run - Using alternative warehouse " ~ initial_wh | upper) }}
             {% do return(initial_wh) %}
 
-        {#- use alternative warehouse if full-refresh run #}
+        {#-- use alternative warehouse if full-refresh run #}
         {% elif flags.FULL_REFRESH and full_wh is not none %}
             {{ dbt_utils.log_info("Full Refresh Run - Using alternative warehouse " ~ full_wh | upper) }}
             {% do return(full_wh) %}
 
-        {#- use alternative warehouse if incremental run #}
+        {#-- use alternative warehouse if incremental run #}
         {% elif relation is not none and inc_wh is not none %}
             {{ dbt_utils.log_info("Incremental Run - Using alternative warehouse " ~ inc_wh | upper) }}
             {% do return(inc_wh) %}        
 
-        {#- use target warehouse if variable not configured for a condition #}
+        {#-- use target warehouse if variable not configured for a condition #}
         {% else %}
             {{ dbt_utils.log_info("Using target warehouse " ~ target.warehouse | upper) }}
             {% do return(target.warehouse) %}
 
         {% endif %}
 
-    {#- use target warehouse if model is not incremental #}
+    {#-- use target warehouse if model is not incremental #}
     {% elif execute and model.config.materialized != 'incremental' %}
         {{ dbt_utils.log_info("Using target warehouse " ~ target.warehouse | upper) }}
         {% do return(target.warehouse) %}
 
-    {#- use target warehouse for parsing #}
+    {#-- use target warehouse for parsing #}
     {% else %}
         {% do return(target.warehouse) %}
 

--- a/macros/warehouse_size.sql
+++ b/macros/warehouse_size.sql
@@ -18,11 +18,6 @@
             {{ dbt_utils.log_info("Full Refresh Run - Using alternative warehouse " ~ full_wh | upper) }}
             {% do return(full_wh) %}
 
-        {#-- use alternative warehouse if incremental run #}
-        {% elif relation is not none and inc_wh is not none %}
-            {{ dbt_utils.log_info("Incremental Run - Using alternative warehouse " ~ inc_wh | upper) }}
-            {% do return(inc_wh) %}        
-
         {#-- use target warehouse if variable not configured for a condition #}
         {% else %}
             {{ dbt_utils.log_info("Using target warehouse " ~ target.warehouse | upper) }}


### PR DESCRIPTION
Removed the ability to set an alternative warehouse for incremental runs as it cannot be isolated properly in the conditions, as there is no distinction in the Jinja context currently between SQL being compiled for a regular run and for `dbt docs generate`. This was resulting in the alternative warehouse being awoken and used for docs generation which is wasteful.

Closes #1
