### PR TITLE
Cleanup Macros for dbt run-operation commands

### DIFF
--- a/macros/cleanup/cleanup.yml
+++ b/macros/cleanup/cleanup.yml
@@ -1,0 +1,10 @@
+version: 2
+
+macros:
+  - name: drop_old_relations
+    description: 'This macro deletes all tables and views that have not been modified in a given number of hours'
+    arguments:
+      - name: age_cutoff_in_hours
+        description: The cutoff in hours since last relation modification. Any relation that has not been modified in this many hours is dropped.
+  - name: drop_empty_schemas
+    description: 'This macro drops all schemas in the target database that are empty, except `PUBLIC` and `INFORMATION_SCHEMA`'

--- a/macros/cleanup/drop_empty_schemas.sql
+++ b/macros/cleanup/drop_empty_schemas.sql
@@ -1,0 +1,51 @@
+{% macro drop_empty_schemas() %}
+
+  {% set cleanup_query %}
+
+      WITH 
+      
+      ALL_SCHEMAS AS (
+        SELECT
+          CONCAT_WS('.', CATALOG_NAME, SCHEMA_NAME) AS SCHEMA_NAME
+        FROM 
+          {{ target.database }}.INFORMATION_SCHEMA.SCHEMATA
+        WHERE 
+          SCHEMA_NAME NOT IN ('INFORMATION_SCHEMA', 'PUBLIC')
+      ),
+
+      NON_EMPTY_SCHEMAS AS (
+        SELECT
+          DISTINCT CONCAT_WS('.', TABLE_CATALOG, TABLE_SCHEMA) AS SCHEMA_NAME
+        FROM 
+          {{ target.database }}.INFORMATION_SCHEMA.TABLES
+        WHERE 
+          TABLE_SCHEMA NOT IN ('INFORMATION_SCHEMA', 'PUBLIC')
+      ),
+
+      EMPTY_SCHEMAS AS (
+        SELECT * FROM ALL_SCHEMAS
+        MINUS
+        SELECT * FROM NON_EMPTY_SCHEMAS
+      )
+
+      SELECT 
+        'DROP SCHEMA ' || SCHEMA_NAME || ';' as DROP_COMMANDS
+      FROM 
+        EMPTY_SCHEMAS
+
+  {% endset %}
+
+    
+  {% set drop_commands = run_query(cleanup_query).columns[0].values() %}
+
+
+  {% if drop_commands %}
+    {% for drop_command in drop_commands %}
+      {% do log(drop_command, True) %}
+      {% do run_query(drop_command) %}
+    {% endfor %}
+  {% else %}
+    {% do log('No schemas to clean.', True) %}
+  {% endif %}
+  
+{% endmacro %}

--- a/macros/cleanup/drop_old_relations.sql
+++ b/macros/cleanup/drop_old_relations.sql
@@ -1,0 +1,40 @@
+{% macro drop_old_relations(age_cutoff_in_hours) %}
+
+  {% set cleanup_query %}
+
+      WITH 
+      
+      MODELS_TO_DROP AS (
+        SELECT
+          CASE 
+            WHEN TABLE_TYPE = 'BASE TABLE' THEN 'TABLE'
+            WHEN TABLE_TYPE = 'VIEW' THEN 'VIEW'
+          END AS RELATION_TYPE,
+          CONCAT_WS('.', TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME) AS RELATION_NAME
+        FROM 
+          {{ target.database }}.INFORMATION_SCHEMA.TABLES
+        WHERE 
+          TABLE_SCHEMA NOT IN ('INFORMATION_SCHEMA', 'PUBLIC')
+          AND 
+          LAST_ALTERED < DATEADD('HOUR', -{{ age_cutoff_in_hours }}, CURRENT_TIMESTAMP)
+      )
+
+      SELECT 
+        'DROP ' || RELATION_TYPE || ' ' || RELATION_NAME || ';' as DROP_COMMANDS
+      FROM 
+        MODELS_TO_DROP
+
+  {% endset %}
+    
+  {% set drop_commands = run_query(cleanup_query).columns[0].values() %}
+
+  {% if drop_commands %}
+    {% for drop_command in drop_commands %}
+      {% do log(drop_command, True) %}
+      {% do run_query(drop_command) %}
+    {% endfor %}
+  {% else %}
+    {% do log('No relations to clean.', True) %}
+  {% endif %}
+  
+{% endmacro %}


### PR DESCRIPTION
This PR includes:
- a `cleanup_old_relations` macro that drops any view or table in the target database that has not been modified in a given number of hours
- a `cleanup_empty_schemas` macro that drops any schema that is empty, except the `INFORMATION_SCHEMA` and `PUBLIC` schemas.
- a documentation yaml describing the macros