### PR TITLE
Enable database selection for clone_schema macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ This macro clones the source schema into the destination schema.
 #### Arguments
 * `source_schema` (required): The source schema name
 * `destination_schema` (required): The destination schema name
+* `source_database` (optional): The source database name
+* `destination_database` (optional): The destination database name
 
 #### Usage
 
@@ -81,6 +83,9 @@ Call the macro as an [operation](https://docs.getdbt.com/docs/using-operations):
 ```
 # for multiple arguments, use the dict syntax
 dbt run-operation clone_schema --args "{'source_schema': 'analytics', 'destination_schema': 'ci_schema'}"
+
+# set the databases
+dbt run-operation clone_schema --args "{'source_schema': 'analytics', 'destination_schema': 'ci_schema', 'source_database': 'production', 'destination_database': 'temp'}"
 ```
 
 ----

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Call the macro as an [operation](https://docs.getdbt.com/docs/using-operations):
 dbt run-operation clone_schema --args "{'source_schema': 'analytics', 'destination_schema': 'ci_schema'}"
 
 # set the databases
-dbt run-operation clone_schema --args "{'source_schema': 'analytics', 'destination_schema': 'ci_schema', 'source_database': 'production', 'destination_database': 'temp'}"
+dbt run-operation clone_schema --args "{'source_schema': 'analytics', 'destination_schema': 'ci_schema', 'source_database': 'production', 'destination_database': 'temp_database'}"
 ```
 
 ----

--- a/macros/clone_schema.sql
+++ b/macros/clone_schema.sql
@@ -1,9 +1,6 @@
-{% macro clone_schema(source_schema, destination_schema, source_database=None, destination_database=None) %}
+{% macro clone_schema(source_schema, destination_schema, source_database=target.database, destination_database=target.database) %}
   
   {% if source_schema and destination_schema %}
-    
-    {% set source_database = target.database if not source_database else source_database %}
-    {% set destination_database = target.database if not destination_database else destination_database %}
 
     {{ (log("Cloning existing schema " ~ source_database ~ "." ~ source_schema ~ 
     " into schema " ~ destination_database ~ "." ~ destination_schema, info=True)) }}

--- a/macros/clone_schema.sql
+++ b/macros/clone_schema.sql
@@ -1,11 +1,16 @@
-{% macro clone_schema(source_schema, destination_schema) %}
+{% macro clone_schema(source_schema, destination_schema, source_database=None, destination_database=None) %}
   
   {% if source_schema and destination_schema %}
     
-    {{ log("Cloning existing schema " ~ source_schema ~ " into schema " ~ destination_schema, info=True) }}
+    {% set source_database = target.database if not source_database else source_database %}
+    {% set destination_database = target.database if not destination_database else destination_database %}
+
+    {{ (log("Cloning existing schema " ~ source_database ~ "." ~ source_schema ~ 
+    " into schema " ~ destination_database ~ "." ~ destination_schema, info=True)) }}
     
     {% call statement('clone_schema', fetch_result=True, auto_begin=False) -%}
-        CREATE OR REPLACE SCHEMA {{ destination_schema }} CLONE {{ source_schema }}
+        CREATE OR REPLACE SCHEMA {{ destination_database }}.{{ destination_schema }} 
+          CLONE {{ source_database }}.{{ source_schema }}
     {%- endcall %}
     
     {%- set result = load_result('clone_schema') -%}

--- a/macros/macros.md
+++ b/macros/macros.md
@@ -3,6 +3,12 @@ This macro clones a schema to a new location.
 
 To use in the command line:
 dbt run-operation clone_schema --args '{"source_schema": "source_schema_name", "destination_schema": "destination_schema_name"}'
+
+Or:
+
+dbt run-operation clone_schema --args '{"source_schema": "source_schema_name", "destination_schema": "destination_schema_name",
+"source_database": "source_database_name",
+"destination_schema": "destination_schema_name"}'
 {% enddocs %}
 
 {% docs warehouse_size %}

--- a/macros/macros.yml
+++ b/macros/macros.yml
@@ -8,5 +8,10 @@ macros:
         description: Source schema name
       - name: destination_schema
         description: Destination schema name
+      - name: source_database
+        description: Source database name (optional)
+      - name: destination_database
+        description: Destination database (optional)
+
   - name: warehouse_size
     description: '{{ doc("warehouse_size") }}'

--- a/macros/macros.yml
+++ b/macros/macros.yml
@@ -9,9 +9,9 @@ macros:
       - name: destination_schema
         description: Destination schema name
       - name: source_database
-        description: Source database name (optional)
+        description: Source database name (optional). Defaults to target database.
       - name: destination_database
-        description: Destination database (optional)
+        description: Destination database (optional). Defaults to target database.
 
   - name: warehouse_size
     description: '{{ doc("warehouse_size") }}'


### PR DESCRIPTION
Add two arguments to clone_schema macro to select source and destination databases.