### PR TITLE
Add a macro to clone databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Otherwise, it returns the target warehouse configured in the profile.
 
 Call the macro from the `snowflake_warehouse` model configuration:
 ```
-{{ 
+{{
     config(
       snowflake_warehouse=snowflake_utils.warehouse_size()
     )
@@ -62,7 +62,7 @@ When a variable is configured for a conditon _and_ that condition is matched whe
 
 ```
 12:00:00 | Concurrency: 16 threads (target='dev')
-12:00:00 | 
+12:00:00 |
 12:00:00 | 1 of 1 START incremental model DBT_MGUINDON.fct_orders... [RUN]
 12:00:00 + Initial Run - Using warehouse TRANSFORMING_XL_WH
 ```
@@ -86,6 +86,27 @@ dbt run-operation clone_schema --args "{'source_schema': 'analytics', 'destinati
 
 # set the databases
 dbt run-operation clone_schema --args "{'source_schema': 'analytics', 'destination_schema': 'ci_schema', 'source_database': 'production', 'destination_database': 'temp_database'}"
+```
+
+### snowflake_utils.clone_database ([source](macros/clone_database.sql))
+This macro clones the source database into the destination database.  The destination database must already exist.  Existing tables in the target will be replaced if already present, but will not be dropped if they no longer exist in the source database.
+
+
+#### Arguments
+* `source_database` (required): The source database name
+* `destination_database` (required): The destination database name
+* `exclude_schemas` (optional): List of schemas to exclude from cloning
+
+#### Usage
+
+Call the macro as an [operation](https://docs.getdbt.com/docs/using-operations):
+
+```
+dbt run-operation clone_database --args "{'source_database': 'production', 'destination_database': 'temp_database'}"
+
+# Excluding schemas
+dbt run-operation clone_database --args "{'source_database': 'production', 'destination_database': 'temp_database', 'exclude_schemas': ['large_legacy_data', 'large_legacy_data2']}"
+
 ```
 
 ### snowflake_utils.drop_schema ([source](macros/drop_schema.sql))

--- a/macros/clone_database.sql
+++ b/macros/clone_database.sql
@@ -1,0 +1,35 @@
+{% macro clone_database(source_database, destination_database, exclude_schemas=[]) %}
+  -- Assumes the target database already exists
+
+  {% if not (source_database and destination_database) %}
+    {{ exceptions.raise_compiler_error("Invalid arguments. Missing source and/or target database") }}
+  {% endif %}
+
+  {% call statement('schemas_to_clone', fetch_result=True, auto_begin=True) -%}
+    SELECT
+      schema_name
+    FROM
+      {{ source_database }}.information_schema.schemata
+    WHERE
+      schema_name NOT IN (
+        {% for exclude_schema in exclude_schemas %}
+          UPPER('{{ exclude_schema }}'),
+        {% endfor %}
+        'INFORMATION_SCHEMA'
+      )
+    ;
+  {%- endcall %}
+  {%- set schemas_to_clone = load_result('schemas_to_clone') -%}
+
+  {% for schema_to_clone in schemas_to_clone['data'] %}
+    {{ log("Cloning schema " ~ source_database ~ "." ~ schema_to_clone[0] ~ " to database " ~ destination_database, info=True) }}
+    {{ clone_schema(
+         source_database=source_database,
+         source_schema=schema_to_clone[0],
+         destination_database=destination_database,
+         destination_schema=schema_to_clone[0]
+       )
+    }}
+  {% endfor %}
+
+{% endmacro %}

--- a/macros/clone_schema.sql
+++ b/macros/clone_schema.sql
@@ -1,22 +1,38 @@
 {% macro clone_schema(source_schema, destination_schema, source_database=target.database, destination_database=target.database) %}
-  
-  {% if source_schema and destination_schema %}
 
-    {{ (log("Cloning existing schema " ~ source_database ~ "." ~ source_schema ~ 
-    " into schema " ~ destination_database ~ "." ~ destination_schema, info=True)) }}
-    
-    {% call statement('clone_schema', fetch_result=True, auto_begin=False) -%}
-        CREATE OR REPLACE SCHEMA {{ destination_database }}.{{ destination_schema }} 
-          CLONE {{ source_database }}.{{ source_schema }}
-    {%- endcall %}
-    
-    {%- set result = load_result('clone_schema') -%}
-    {{ log(result['data'][0][0], info=True)}}
-
-  {% else %}
-    
-    {{ exceptions.raise_compiler_error("Invalid arguments. Missing source schema and/or destination schema") }}
-
+  {% if not (source_database and source_schema and destination_database and destination_schema) %}
+    {{ exceptions.raise_compiler_error("Invalid arguments. Missing source and/or target schema/database") }}
   {% endif %}
+
+  {{
+    log("Cloning existing schema " ~ source_database ~ "." ~ source_schema ~
+    " into schema " ~ destination_database ~ "." ~ destination_schema, info=True)
+  }}
+
+  {% call statement(tables_to_clone, fetch_result=True, auto_begin=True) -%}
+    SELECT
+      CASE WHEN table_type = 'VIEW' THEN
+        'CREATE OR REPLACE VIEW {{ destination_database }}.{{ destination_schema }}."' || table_name || '" AS (SELECT * FROM ' || '{{ source_database }}.{{ source_schema }}."' || table_name || '");'
+      ELSE
+        'CREATE OR REPLACE' || IFF(is_transient = 'YES', ' TRANSIENT ', ' ') || 'TABLE {{ destination_database }}.{{ destination_schema }}."' || table_name || '" CLONE ' || '{{ source_database }}.{{ source_schema }}."' || table_name || '";'
+      END AS stmt
+    FROM
+      {{ source_database }}.information_schema.tables
+    WHERE
+      table_schema = UPPER('{{ source_schema }}')
+  {%- endcall %}
+  {%- set tables_to_clone = load_result(tables_to_clone) -%}
+
+  {% call statement('create_schema', fetch_result=False, auto_begin=True) -%}
+    CREATE SCHEMA IF NOT EXISTS {{ destination_database}}.{{ destination_schema }};
+  {%- endcall %}
+
+  {% for clone_table in tables_to_clone['data'] %}
+    {{ log("Running " ~ clone_table[0], info=True) }}
+
+    {% call statement('clone_table', fetch_result=False, auto_begin=True) -%}
+      {{ clone_table[0] }}
+    {%- endcall %}
+  {% endfor %}
 
 {% endmacro %}


### PR DESCRIPTION
In our dbt implementation, we have two production databases: PROD_RAW and PROD_WH.  PROD_RAW
houses all of the raw source data and PROD_WH is where dbt builds models.  These production database
are owned by a PROD_TRANSFORMER role.  dbt developers use the DEVELOPER role.  When we try
using the simple `create database dev_wh clone prod_wh` as a DEVELOPER, all of the tables are still
owned by the PROD_TRANSFORMER role and thus the developer cannot run dbt in the DEV_WH database.

In order to overcome this limitation, I've modified the `clone_schema` macro to clone each table/view individually,
which ends up creating tables owned by the DEVELOPER role.