### PR TITLE
Update dbt_project config-version to 2 to silence warnings with dbt 0.17.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Out-of-the-box, the macro will return the `target.warehouse` for each condition,
 |----------|-------------|:--------:|
 |snowflake_utils:initial_run_warehouse|Alternative warehouse when the relation doesn't exist|No|
 |snowflake_utils:full_refresh_run_warehouse|Alternative warehouse when doing a `--full-refresh`|No|
+|snowflake_utils:incremental_run_warehouse|Default warehouse for incremental runs|No|
 
 An example `dbt_project.yml` configuration:
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,9 @@
 name: 'snowflake_utils'
-version: '0.0.1'
+version: '0.2.0'
 
-require-dbt-version: ">=0.15.0"
+config-version: 2
+
+require-dbt-version: ">=0.17.0"
 
 source-paths: ["models"]
 target-path: "target"


### PR DESCRIPTION
After the release of dbt 0.17.0, the snowflake_utils module causes the following deprecation warning to be emitted by dbt:
```
* Deprecation Warning: dbt v0.17.0 introduces a new config format for the
dbt_project.yml file. Support for the existing version 1 format will be removed
in a future release of dbt. The following packages are currently configured with
config version 1:
 - snowflake_utils

For upgrading instructions, consult the documentation:
  https://docs.getdbt.com/docs/guides/migration-guide/upgrading-to-0-17-0
```
This silences that warning.

I also propose bumping the minor version number if you merge this PR to 0.2.0 from 0.1.3.  I represented my intent by setting the dbt_project.yml::version to `0.2.0` although, that field is not yet used internally by dbt and you will need to tag post merge and whatever other mechanisms are needed for dbt-hub to have new versions published.