### PR TITLE
fix: session db/schema and macro references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target/
 dbt_modules/
 dbt_packages/
 logs/
+.idea

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ schema.yml
 
 models:
   - name: ACCOUNT
+    +schema: FINANCE
     config:
       meta:
         database_tags:
@@ -134,6 +135,9 @@ models:
 The above means:
 The Snowflake table ACCOUNT will have the tag 'accounting_row_string' set to the value 'visible'.
 Its columns ACCOUNT_NAME and ACCOUNT_NUMBER will both have the tag 'accounting_col_string' set to the value 'visible'
+
+All tags are created in the schema of the model where they are added. In the above example the tags will end up
+in the FINANCE schema (name depends on how [DBT has been configured](https://docs.getdbt.com/docs/build/custom-schemas)).
 
 The macro must be called as part of on-run-end, so add the following to dbt_project.yml:
 ```


### PR DESCRIPTION
Hi,

I could not get it to work neither using DBT 1.2 or 1.3. Calls that are made to macros within the package fail and tags are being looked for and created in the database and schema specified in the profile, not the database/schema of the model.

With the changes suggested by this PR I got it to work, by:

* Adding `USE DATABASE ..` and `USE SCHEMA ...` in the main macro. This could also be solved by using the fully qualified schema and table names everywhere but this solution seemed easier. This will also mean that tags are created in the database/schema of the model. Makes sense to me, but I am not sure what the expected behavior was? If your DBT setup creates all models in the same database, this won't be an issue.

* Prefixed the macro calls with `snowflake_utils`. This fixed the issues I was having, but not sure why the prefix is needed from within the package.

* Also had issues with the initial run, since the macro didn't return anything and DBT tried to execute it, which rendered an error (fixed by returning an empty string):

```
Database Error
  001003 (42000): SQL compilation error:
  syntax error line 1 at position 0 unexpected 'None'.
```

Related to https://github.com/Montreal-Analytics/dbt-snowflake-utils/issues/24

But TBH, I don't really understand why I am facing these issues seeing that https://github.com/Montreal-Analytics/dbt-snowflake-utils/pull/21 has been merged and things seem to work fine at that point.