### PR TITLE
feat: add macro apply_cached_tag

### DIFF
--- a/macros/apply_cached_tag.sql
+++ b/macros/apply_cached_tag.sql
@@ -1,0 +1,26 @@
+{% macro apply_cached_tag(this,tag_name,default_value) %}
+    {%- set tag_database = this.database -%}
+    {%- set tag_schema = this.schema -%}
+    {%- set cached_tag_value = get_cached_tag_value(tag_database,tag_schema,this,tag_name,default_value) -%}
+
+
+    {%- call statement('apply_cached_tag', fetch_result=True) -%}
+        ALTER TABLE {{ this }} SET TAG {{ tag_database }}.{{ tag_schema }}.{{ tag_name }} = '{{ cached_tag_value }}'
+    {%- endcall -%}
+{% endmacro %}
+
+
+{% macro get_cached_tag_value(database,schema,this,tag_name,default_value) %}
+  {% set get_cached_tag_value_query %}
+  SELECT coalesce((SELECT tag_value FROM {{tag_database}}.staging.stg_account_usage__tag_references WHERE lower(concat_ws('.',object_database,object_schema,object_name)) = '{{ this | lower }}' AND lower(tag_schema) = '{{ tag_schema | lower}}' AND lower(tag_name) = '{{tag_name|lower}}' AND object_deleted is null),'{{default_value}}')
+  {% endset %}
+  {% set results = run_query(get_cached_tag_value_query) %}
+  {% if execute %}
+  {# Return the first column #}
+  {% set result_scalar = results.columns[0].values()[0] %}
+  {% else %}
+  {% set result_scalar = "" %}
+  {% endif %}
+  {{ return(result_scalar) }}
+
+{% endmacro %}

--- a/macros/macros.md
+++ b/macros/macros.md
@@ -136,7 +136,7 @@ Add this post hook for each tag you want to use the previous tag during the ment
 
 models:
     my_project:
-        +post-hook: "{%set tag_value = (select coalesce((select tag_value from {{this.database}}.staging.stg_account_usage__tag_references where concat_ws('.',object_database,object_schema,object_name) = '{{ this }}' and object_deleted is null),'some-default-value')); alter table {{ this }} set TAG {{this.database}}.{{this.schema}}.tag_name = $tag_value"
+        +post-hook: "{{ apply_cached_tag(this,'some-tag-name','some-default-value') }}"
 
 ```
 This requires:

--- a/macros/macros.md
+++ b/macros/macros.md
@@ -139,6 +139,31 @@ models:
         +post-hook: "{{ apply_cached_tag(this,'some-tag-name','some-default-value') }}"
 
 ```
+
+{% enddocs %}
+{% docs apply_cached_tag %}
+This macro applies the previous tag, cached in a dbt model.
+
+
+#### Arguments
+* `this` (required): The database representation of the current model - [this](https://docs.getdbt.com/reference/dbt-jinja-functions/this).
+* `tag_name` (required): The name of the tag to apply value from cache.
+* `default_value` (required): A default value to be applied if tag not found in cache. Will be used for the first time the model runs.
+
+#### Usage
+
+Add the following post-hook to `dbt_project.yml`:
+```yml
+# dbt_project.yml
+
+...
+
+models:
+    my_project:
+        +post-hook: "{{ apply_cached_tag(this,'some-tag-name','some-default-value') }}"
+
+```
+
 This requires:
 
 - Create a base model, materialized as `table`, on top of the view [tag_references](https://docs.snowflake.com/en/sql-reference/account-usage/tag_references).

--- a/macros/macros.yml
+++ b/macros/macros.yml
@@ -12,7 +12,7 @@ macros:
         description: Source database name (optional). Defaults to target database.
       - name: destination_database
         description: Destination database (optional). Defaults to target database.
-        
+
   - name: drop_schema
     description: '{{ doc("drop_schema") }}'
     arguments:
@@ -20,7 +20,7 @@ macros:
         description: Schema to drop
       - name: database
         description: Database name (optional). Defaults to target database.
-        
+
   - name: warehouse_size
     description: '{{ doc("warehouse_size") }}'
 
@@ -29,3 +29,12 @@ macros:
     arguments:
       - name: results
         description: The on-run-end context object
+  - name: apply_cached_tag
+    description: '{{ doc("apply_cached_tag") }}'
+    arguments:
+      - name: this
+        description: The database representation of the current model
+      - name: tag_name
+        description: The name of the tag to apply value from cache
+      - name: default_value
+        description: A default value to be applied if tag not found in cache. Will be used for the first time the model runs


### PR DESCRIPTION
This PR suggests a way to address the gap between the time a **model run** is complete and the **dbt run** is complete. by using the previous tag during this gap. This way, the tag's is always available.