### PR TITLE
Feat/Fix typo in macros.yml

### DIFF
--- a/macros/macros.yml
+++ b/macros/macros.yml
@@ -49,7 +49,7 @@ macros:
       - name: database
         description: "[Optional] Database name. Defaults to target database."
 
-  - name: grant_ownershop_on_schema_objects
+  - name: grant_ownership_on_schema_objects
     arguments:
       - name: new_owner_role
         description: The new owner role of the newly created object


### PR DESCRIPTION
There's a typo in the macros.yml file. This raises a warning when a project that uses this package is invoked.

* [WARNING]: Found patch for macro "grant_ownershop_on_schema_objects" which was not found