### PR TITLE
feat: add environment variables for tag database and schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Its columns ACCOUNT_NAME and ACCOUNT_NUMBER will both have the tag 'accounting_c
 All tags are created in the schema of the model where they are added, by default. In the above example the tags will end up
 in the FINANCE schema (name depends on how [DBT has been configured](https://docs.getdbt.com/docs/build/custom-schemas)).
 If the tag needs to be created in a different location/referred from different location, the below two environment 
-variables need to be added in dbt-project.yml file as below:
+variables need to be added in dbt_project.yml file as below:
 
 ```yml
 # dbt_project.yml

--- a/README.md
+++ b/README.md
@@ -188,8 +188,18 @@ The above means:
 The Snowflake table ACCOUNT will have the tag 'accounting_row_string' set to the value 'visible'.
 Its columns ACCOUNT_NAME and ACCOUNT_NUMBER will both have the tag 'accounting_col_string' set to the value 'visible'
 
-All tags are created in the schema of the model where they are added. In the above example the tags will end up
+All tags are created in the schema of the model where they are added, by default. In the above example the tags will end up
 in the FINANCE schema (name depends on how [DBT has been configured](https://docs.getdbt.com/docs/build/custom-schemas)).
+If the tag needs to be created in a different location/referred from different location, the below two environment 
+variables need to be added in dbt-project.yml file as below:
+
+```yml
+# dbt_project.yml
+
+common_tag_database: 'audit'
+common_tag_schema: 'tags'
+```
+In the above example, the tags will be created in audit.tags .
 
 The macro must be called as part of on-run-end, so add the following to dbt_project.yml:
 ```

--- a/macros/apply_meta_as_tags.sql
+++ b/macros/apply_meta_as_tags.sql
@@ -10,8 +10,8 @@
     {% for res in results -%}
         {% if snowflake_utils.model_contains_tag_meta(res.node) %}
             
-            {%- set model_database = var('common_tag_database') or res.node.database -%}
-            {%- set model_schema = var('common_tag_schema') or res.node.schema -%}
+            {%- set model_database = var('snowflake_utils:common_tag_database') or res.node.database -%}
+            {%- set model_schema = var('snowflake_utils:common_tag_schema') or res.node.schema -%}
             {%- set model_schema_full = model_database+'.'+model_schema -%}
             {%- set model_alias = res.node.alias -%}
 

--- a/macros/apply_meta_as_tags.sql
+++ b/macros/apply_meta_as_tags.sql
@@ -67,16 +67,18 @@
             {{ log(existing_tags_for_table, info=True) }}
 
             {% for table_tag in model_meta.database_tags %}
-                {{ snowflake_utils.create_tag_if_missing(tag_schema_full|upper,current_tags_in_schema,table_tag|upper) }}
+                {% set table_tag_full = tag_schema_full+'.'+table_tag %}
+                {{ snowflake_utils.create_tag_if_missing(current_tags_in_schema,table_tag_full|upper) }}
                 {% set desired_tag_value = model_meta.database_tags[table_tag] %}
-                {{ snowflake_utils.set_table_tag_value_if_different(tag_schema_full|upper,model_alias|upper,table_tag,desired_tag_value,existing_tags_for_table) }}
+                {{ snowflake_utils.set_table_tag_value_if_different(model_alias|upper,table_tag_full,desired_tag_value,existing_tags_for_table) }}
             {% endfor %}
             {% for column in res.node.columns %}
                 {% for column_tag in res.node.columns[column].meta.database_tags %}
+                    {% set column_tag_full = tag_schema_full+'.'+column_tag %}
                     {{log(column_tag,info=True)}}
-                    {{ snowflake_utils.create_tag_if_missing(tag_schema_full|upper,current_tags_in_schema,column_tag|upper)}}
+                    {{ snowflake_utils.create_tag_if_missing(current_tags_in_schema,column_tag_full|upper)}}
                     {% set desired_tag_value = res.node.columns[column].meta.database_tags[column_tag] %}
-                    {{ snowflake_utils.set_column_tag_value_if_different(tag_schema_full|upper,model_alias|upper,column|upper,column_tag,desired_tag_value,existing_tags_for_table)}}
+                    {{ snowflake_utils.set_column_tag_value_if_different(model_alias|upper,column|upper,column_tag_full,desired_tag_value,existing_tags_for_table)}}
                 {% endfor %}
             {% endfor %}
             {{ log("========== Finished processing tags for "+model_alias+" ==========", info=True) }}
@@ -87,8 +89,8 @@
   {{ return('') }}
 {% endmacro %}
 
-{# 
--- Given a node in a Result object, returns True if either the model meta contains database_tags, 
+{#
+-- Given a node in a Result object, returns True if either the model meta contains database_tags,
 -- or any of the column's meta contains database_tags.
 -- Otherwise it returns False
 #}
@@ -96,7 +98,7 @@
 	{% if model_node.meta.database_tags %}
         {{ return(True) }}
 	{% endif %}
-    {# 
+    {#
     -- For compatibility with the old results structure
     #}
     {% if model_node.config.meta.database_tags %}
@@ -110,17 +112,17 @@
     {{ return(False) }}
 {% endmacro %}
 
-{# 
+{#
 -- Snowflake tags must exist before they are used.
--- Given a list of all the existing tags in the account (all_tag_names), 
+-- Given a list of all the existing tags in the account (all_tag_names),
 -- checks if the new tag (new_tag) is already in the list and
 -- creates it in Snowflake if it doesn't.
 #}
-{% macro create_tag_if_missing(tag_schema_full,all_tag_names,new_tag) %}
-	{% if new_tag not in all_tag_names %}
+{% macro create_tag_if_missing(all_tag_names,new_tag) %}
+	{% if new_tag.split('.')[2] not in all_tag_names %}
 		{{ log('Creating missing tag '+new_tag, info=True) }}
         {%- call statement('main', fetch_result=True) -%}
-            create tag {{tag_schema_full}}.{{new_tag}}
+            create tag {{new_tag}}
         {%- endcall -%}
         {{ all_tag_names.append(new_tag)}}
 		{{ log(load_result('main').data, info=True) }}
@@ -130,19 +132,18 @@
 {% endmacro %}
 
 -- select LEVEL,OBJECT_NAME,COLUMN_NAME,UPPER(TAG_NAME) as TAG_NAME,TAG_VALUE
-{# 
+{#
 -- Updates the value of a Snowflake table tag, if the provided value is different.
 -- existing_tags contains the results from querying tag_references_all_columns.
--- The first column (attribute '0') contains the name of database and schema of tag
--- The second column (attribute '1') contains 'TABLE' or 'COLUMN', since we're looking
+-- The first column (attribute '0') contains 'TABLE' or 'COLUMN', since we're looking
 -- at table tags here then we include only 'TABLE' values.
--- The third column (attribute '2') contains the name of the table, we filter on that.
--- The third column (attribute '3') contains the name of the column, not relevant here.
--- The fourth column (attribute '4') contains the tag name, so we filter on that too.
--- The fifth column (index 5) contains the value of the tag, so we compare with the desired_tag_value
+-- The second column (attribute '1') contains the name of the table, we filter on that.
+-- The third column (attribute '2') contains the name of the column, not relevant here.
+-- The fourth column (attribute '3') contains the tag name, so we filter on that too.
+-- The fifth column (index 4) contains the value of the tag, so we compare with the desired_tag_value
 -- to see if we need to update it
 #}
-{% macro set_table_tag_value_if_different(tag_schema_full,table_name,tag_name,desired_tag_value,existing_tags) %}
+{% macro set_table_tag_value_if_different(table_name,tag_name,desired_tag_value,existing_tags) %}
     {{ log('Ensuring tag '+tag_name+' has value '+desired_tag_value+' at table level', info=True) }}
     {{ log(existing_tags, info=True) }}
     {%- set existing_tag_for_table = existing_tags|selectattr('0','equalto','TABLE')|selectattr('1','equalto',table_name|upper)|selectattr('3','equalto',tag_name|upper)|list -%}
@@ -153,24 +154,23 @@
     {% else %}
         {{ log('Setting tag value for '+tag_name+' to value '+desired_tag_value, info=True) }}
         {%- call statement('main', fetch_result=True) -%}
-            alter table {{table_name}} set tag {{tag_schema_full}}.{{tag_name}} = '{{desired_tag_value}}'
+            alter table {{table_name}} set tag {{tag_name}} = '{{desired_tag_value}}'
         {%- endcall -%}
         {{ log(load_result('main').data, info=True) }}
     {% endif %}
 {% endmacro %}
-{# 
+{#
 -- Updates the value of a Snowflake column tag, if the provided value is different.
 -- existing_tags contains the results from querying tag_references_all_columns.
--- The first column (attribute '0') contains the name of database and schema of tag
--- The second column (attribute '1') contains 'TABLE' or 'COLUMN', since we're looking
+-- The first column (attribute '0') contains 'TABLE' or 'COLUMN', since we're looking
 -- at column tags here then we include only 'COLUMN' values.
--- The third column (attribute '2') contains the name of the table, we filter on that.
--- The fourth column (attribute '3') contains the name of the column, we filter on that.
--- The fifth column (attribute '4') contains the tag name, so we filter on that too.
--- The sixth column (index 5) contains the value of the tag, so we compare with the desired_tag_value
+-- The second column (attribute '1') contains the name of the table, we filter on that.
+-- The third column (attribute '2') contains the name of the column, we filter on that.
+-- The fourth column (attribute '3') contains the tag name, so we filter on that too.
+-- The fifth column (index 4) contains the value of the tag, so we compare with the desired_tag_value
 -- to see if we need to update it
 #}
-{% macro set_column_tag_value_if_different(tag_schema_full,table_name,column_name,tag_name,desired_tag_value,existing_tags) %}
+{% macro set_column_tag_value_if_different(table_name,column_name,tag_name,desired_tag_value,existing_tags) %}
     {{ log('Ensuring tag '+tag_name+' has value '+desired_tag_value+' at column level', info=True) }}
     {%- set existing_tag_for_column = existing_tags|selectattr('0','equalto','COLUMN')|selectattr('1','equalto',table_name|upper)|selectattr('2','equalto',column_name|upper)|selectattr('3','equalto',tag_name|upper)|list -%}
     {{ log('Filtered tags for column:', info=True) }}
@@ -180,7 +180,7 @@
     {% else %}
         {{ log('Setting tag value for '+tag_name+' to value '+desired_tag_value, info=True) }}
         {%- call statement('main', fetch_result=True) -%}
-            alter table {{table_name}} modify column {{column_name}} set {{tag_schema_full}}.tag {{tag_name}} = '{{desired_tag_value}}'
+            alter table {{table_name}} modify column {{column_name}} set tag {{tag_name}} = '{{desired_tag_value}}'
         {%- endcall -%}
         {{ log(load_result('main').data, info=True) }}
     {% endif %}

--- a/macros/apply_meta_as_tags.sql
+++ b/macros/apply_meta_as_tags.sql
@@ -13,8 +13,8 @@
             {%- set tag_database = var('common_tag_database') -%}
             {%- set tag_schema = var('common_tag_schema') -%}
             {%- set tag_schema_full = tag_database+'.'+tag_schema -%}
-            {%- set model_database = var('common_tag_database') or res.node.database -%}
-            {%- set model_schema = var('common_tag_schema') or res.node.schema -%}
+            {%- set model_database = res.node.database -%}
+            {%- set model_schema = res.node.schema -%}
             {%- set model_schema_full = model_database+'.'+model_schema -%}
             {%- set model_alias = res.node.alias -%}
 

--- a/macros/apply_meta_as_tags.sql
+++ b/macros/apply_meta_as_tags.sql
@@ -11,8 +11,8 @@
         {% if snowflake_utils.model_contains_tag_meta(res.node) %}
 
             -- Tagging database and schema will be fetched from the below environment variables.
-            {%- set tag_database = var('common_tag_database') -%}
-            {%- set tag_schema = var('common_tag_schema') -%}
+            {%- set tag_database = var('common_tag_database', res.node.database) -%}
+            {%- set tag_schema = var('common_tag_schema', res.node.schema) -%}
             {%- set tag_schema_full = tag_database+'.'+tag_schema -%}
 
             {%- set model_database = res.node.database -%}

--- a/macros/apply_meta_as_tags.sql
+++ b/macros/apply_meta_as_tags.sql
@@ -11,6 +11,7 @@
         {% if snowflake_utils.model_contains_tag_meta(res.node) %}
 
             -- Tagging database and schema will be fetched from the below environment variables.
+            -- If not given any enviornment variables, model database and schema will be used
             {%- set tag_database = var('common_tag_database', res.node.database) -%}
             {%- set tag_schema = var('common_tag_schema', res.node.schema) -%}
             {%- set tag_schema_full = tag_database+'.'+tag_schema -%}

--- a/macros/apply_meta_as_tags.sql
+++ b/macros/apply_meta_as_tags.sql
@@ -70,7 +70,7 @@
                 {% set table_tag_full = tag_schema_full+'.'+table_tag %}
                 {{ snowflake_utils.create_tag_if_missing(current_tags_in_schema,table_tag_full|upper) }}
                 {% set desired_tag_value = model_meta.database_tags[table_tag] %}
-                {{ snowflake_utils.set_table_tag_value_if_different(model_alias|upper,table_tag_full,desired_tag_value,existing_tags_for_table) }}
+                {{ snowflake_utils.set_table_tag_value_if_different(model_alias|upper,table_tag_full|upper,desired_tag_value,existing_tags_for_table) }}
             {% endfor %}
             {% for column in res.node.columns %}
                 {% for column_tag in res.node.columns[column].meta.database_tags %}
@@ -78,7 +78,7 @@
                     {{log(column_tag,info=True)}}
                     {{ snowflake_utils.create_tag_if_missing(current_tags_in_schema,column_tag_full|upper)}}
                     {% set desired_tag_value = res.node.columns[column].meta.database_tags[column_tag] %}
-                    {{ snowflake_utils.set_column_tag_value_if_different(model_alias|upper,column|upper,column_tag_full,desired_tag_value,existing_tags_for_table)}}
+                    {{ snowflake_utils.set_column_tag_value_if_different(model_alias|upper,column|upper,column_tag_full|upper,desired_tag_value,existing_tags_for_table)}}
                 {% endfor %}
             {% endfor %}
             {{ log("========== Finished processing tags for "+model_alias+" ==========", info=True) }}

--- a/macros/apply_meta_as_tags.sql
+++ b/macros/apply_meta_as_tags.sql
@@ -10,8 +10,8 @@
     {% for res in results -%}
         {% if snowflake_utils.model_contains_tag_meta(res.node) %}
             
-            {%- set model_database = res.node.database -%}
-            {%- set model_schema = res.node.schema -%}
+            {%- set model_database = var('common_tag_database') or res.node.database -%}
+            {%- set model_schema = var('common_tag_schema') or res.node.schema -%}
             {%- set model_schema_full = model_database+'.'+model_schema -%}
             {%- set model_alias = res.node.alias -%}
 

--- a/macros/apply_meta_as_tags.sql
+++ b/macros/apply_meta_as_tags.sql
@@ -10,8 +10,8 @@
     {% for res in results -%}
         {% if snowflake_utils.model_contains_tag_meta(res.node) %}
             
-            {%- set model_database = var('snowflake_utils:common_tag_database') or res.node.database -%}
-            {%- set model_schema = var('snowflake_utils:common_tag_schema') or res.node.schema -%}
+            {%- set model_database = var('common_tag_database') or res.node.database -%}
+            {%- set model_schema = var('common_tag_schema') or res.node.schema -%}
             {%- set model_schema_full = model_database+'.'+model_schema -%}
             {%- set model_alias = res.node.alias -%}
 

--- a/macros/apply_meta_as_tags.sql
+++ b/macros/apply_meta_as_tags.sql
@@ -9,10 +9,12 @@
     {%- set tags_by_schema = {} -%}
     {% for res in results -%}
         {% if snowflake_utils.model_contains_tag_meta(res.node) %}
-            
+
+            -- Tagging database and schema will be fetched from the below environment variables.
             {%- set tag_database = var('common_tag_database') -%}
             {%- set tag_schema = var('common_tag_schema') -%}
             {%- set tag_schema_full = tag_database+'.'+tag_schema -%}
+
             {%- set model_database = res.node.database -%}
             {%- set model_schema = res.node.schema -%}
             {%- set model_schema_full = model_database+'.'+model_schema -%}
@@ -130,13 +132,14 @@
 -- select LEVEL,OBJECT_NAME,COLUMN_NAME,UPPER(TAG_NAME) as TAG_NAME,TAG_VALUE
 {# 
 -- Updates the value of a Snowflake table tag, if the provided value is different.
--- existing_tags contains the results from querying tag_references_all_columns. 
--- The first column (attribute '0') contains 'TABLE' or 'COLUMN', since we're looking
+-- existing_tags contains the results from querying tag_references_all_columns.
+-- The first column (attribute '0') contains the name of database and schema of tag
+-- The second column (attribute '1') contains 'TABLE' or 'COLUMN', since we're looking
 -- at table tags here then we include only 'TABLE' values.
--- The second column (attribute '1') contains the name of the table, we filter on that.
--- The third column (attribute '2') contains the name of the column, not relevant here.
--- The fourth column (attribute '3') contains the tag name, so we filter on that too.
--- The fifth column (index 4) contains the value of the tag, so we compare with the desired_tag_value
+-- The third column (attribute '2') contains the name of the table, we filter on that.
+-- The third column (attribute '3') contains the name of the column, not relevant here.
+-- The fourth column (attribute '4') contains the tag name, so we filter on that too.
+-- The fifth column (index 5) contains the value of the tag, so we compare with the desired_tag_value
 -- to see if we need to update it
 #}
 {% macro set_table_tag_value_if_different(tag_schema_full,table_name,tag_name,desired_tag_value,existing_tags) %}
@@ -157,13 +160,14 @@
 {% endmacro %}
 {# 
 -- Updates the value of a Snowflake column tag, if the provided value is different.
--- existing_tags contains the results from querying tag_references_all_columns. 
--- The first column (attribute '0') contains 'TABLE' or 'COLUMN', since we're looking
+-- existing_tags contains the results from querying tag_references_all_columns.
+-- The first column (attribute '0') contains the name of database and schema of tag
+-- The second column (attribute '1') contains 'TABLE' or 'COLUMN', since we're looking
 -- at column tags here then we include only 'COLUMN' values.
--- The second column (attribute '1') contains the name of the table, we filter on that.
--- The third column (attribute '2') contains the name of the column, we filter on that.
--- The fourth column (attribute '3') contains the tag name, so we filter on that too.
--- The fifth column (index 4) contains the value of the tag, so we compare with the desired_tag_value
+-- The third column (attribute '2') contains the name of the table, we filter on that.
+-- The fourth column (attribute '3') contains the name of the column, we filter on that.
+-- The fifth column (attribute '4') contains the tag name, so we filter on that too.
+-- The sixth column (index 5) contains the value of the tag, so we compare with the desired_tag_value
 -- to see if we need to update it
 #}
 {% macro set_column_tag_value_if_different(tag_schema_full,table_name,column_name,tag_name,desired_tag_value,existing_tags) %}


### PR DESCRIPTION
This PR is for adding the environment variables for tag database and schema which should allow users to create the tag in different centralised location and use it in the models. This is for the issue mentioned [here](https://github.com/Montreal-Analytics/dbt-snowflake-utils/issues/28).

If not given any environment variables, the existing functionality will not get affected and tags will be created in the same database and schema as models.

README.md has been updated with the details and it is tested with the sample model on dbt v1.6.