### PR TITLE
fix: correct cache key

### DIFF
--- a/macros/apply_meta_as_tags.sql
+++ b/macros/apply_meta_as_tags.sql
@@ -125,7 +125,7 @@
         {%- call statement('main', fetch_result=True) -%}
             create tag {{new_tag}}
         {%- endcall -%}
-        {{ all_tag_names.append(new_tag)}}
+        {{ all_tag_names.append(new_tag.split('.')[2])}}
 		{{ log(load_result('main').data, info=True) }}
 	{% else %}
 		{{ log('Tag already exists: '+new_tag, info=True) }}


### PR DESCRIPTION
This package uses a cache to check if a tag exists or if it needs to be created. Once a tag is created it is added to the cache. This did not work properly, since the different keys were used at cache lookup (tag name) and add to cache (fully qualified tag name).

I noticed this in a DBT project where multiple models, in the same schema, are creating table tags independently of each other. If the first model creates the tag, the next model would also try to create it leading to this error:

`09:23:58  Tag already exists: GOLD.DBT_CV_DEV_VALIDATIONS.DBT_VALIDATION_KEY`