### PR TITLE
Updated dbt_utils package dependency.

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: 1.1.1
+    version: 1.2.0


### PR DESCRIPTION
dbt has had a recent launch of new features, among others the introduction of unit tests. That lead to an overhaul of their syntax, and an update to their dbt_utils package. The snowflake_utils has a hard-coded dependency on the now outdated dbt_utils package. I have updated that dependency to the last version dbt_utils=1.2.0